### PR TITLE
feat: 🎸 added custom properties

### DIFF
--- a/src/__tests__/array.test.ts
+++ b/src/__tests__/array.test.ts
@@ -324,6 +324,160 @@ test('should create nullable type arrays', () => {
   `);
 });
 
+test('should create custom property arrays', () => {
+  expect(
+    new AvroSchemaBuilder('primitive')
+      .record('record.array')
+      .addField(
+        new ArrayField({
+          name: 'boolean_array',
+          doc: 'boolean array',
+          type: 'boolean',
+          order: FieldOrder.descending,
+          nullable: true,
+        }).prop('customProp', 'val'),
+      )
+      .addField(
+        new ArrayField({
+          name: 'bytes_array',
+          doc: 'bytes array',
+          type: 'bytes',
+          order: FieldOrder.ignore,
+        }).prop('customProp', 'val'),
+      )
+      .addField(
+        new ArrayField({
+          name: 'double_array',
+          doc: 'double array',
+          type: 'double',
+          order: FieldOrder.ignore,
+        }).prop('customProp', 'val'),
+      )
+      .addField(
+        new ArrayField({
+          name: 'float_array',
+          doc: 'float array',
+          type: 'float',
+          order: FieldOrder.ascending,
+        }).prop('customProp', 'val'),
+      )
+      .addField(
+        new ArrayField({
+          name: 'int_array',
+          doc: 'int array',
+          type: 'int',
+          order: FieldOrder.ascending,
+        }).prop('customProp', 'val'),
+      )
+      .addField(
+        new ArrayField({
+          name: 'long_array',
+          doc: 'long array',
+          type: 'long',
+          order: FieldOrder.ignore,
+        }).prop('customProp', 'val'),
+      )
+      .addField(
+        new ArrayField({
+          name: 'string_array',
+          doc: 'string array',
+          type: 'string',
+          order: FieldOrder.descending,
+        }).prop('customProp', 'val'),
+      )
+      .addField(
+        new MapField({
+          name: 'map_field',
+          type: 'string',
+        }).prop('customProp', 'val'),
+      )
+      .compile(),
+  ).toMatchInlineSnapshot(`
+    {
+      "fields": [
+        {
+          "customProp": "val",
+          "name": "boolean_array",
+          "type": [
+            "null",
+            {
+              "customProp": "val",
+              "items": "boolean",
+              "type": "array",
+            },
+          ],
+        },
+        {
+          "customProp": "val",
+          "name": "bytes_array",
+          "type": {
+            "customProp": "val",
+            "items": "bytes",
+            "type": "array",
+          },
+        },
+        {
+          "customProp": "val",
+          "name": "double_array",
+          "type": {
+            "customProp": "val",
+            "items": "double",
+            "type": "array",
+          },
+        },
+        {
+          "customProp": "val",
+          "name": "float_array",
+          "type": {
+            "customProp": "val",
+            "items": "float",
+            "type": "array",
+          },
+        },
+        {
+          "customProp": "val",
+          "name": "int_array",
+          "type": {
+            "customProp": "val",
+            "items": "int",
+            "type": "array",
+          },
+        },
+        {
+          "customProp": "val",
+          "name": "long_array",
+          "type": {
+            "customProp": "val",
+            "items": "long",
+            "type": "array",
+          },
+        },
+        {
+          "customProp": "val",
+          "name": "string_array",
+          "type": {
+            "customProp": "val",
+            "items": "string",
+            "type": "array",
+          },
+        },
+        {
+          "customProp": "val",
+          "name": "map_field",
+          "type": {
+            "customProp": "val",
+            "type": "map",
+            "values": "string",
+          },
+        },
+      ],
+      "name": "primitive",
+      "namespace": "record.array",
+      "type": "record",
+    }
+  `);
+});
+
 test('should create object type arrays', () => {
   expect(
     new AvroSchemaBuilder('primitive')

--- a/src/__tests__/enum.test.ts
+++ b/src/__tests__/enum.test.ts
@@ -34,6 +34,13 @@ test('should create a schema', () => {
           nullable: true,
         }),
       )
+      .addField(
+        new EnumField({
+          name: 'enum_field_with_customProp',
+          type: Object.values(Color),
+          defaultValue: Color.green,
+        }).prop('customProp', 'val'),
+      )
       .compile(),
   ).toMatchInlineSnapshot(`
     {
@@ -83,6 +90,21 @@ test('should create a schema', () => {
               "type": "enum",
             },
           ],
+        },
+        {
+          "customProp": "val",
+          "name": "enum_field_with_customProp",
+          "type": {
+            "customProp": "val",
+            "default": "green",
+            "name": "enum_field_with_customProp",
+            "symbols": [
+              "red",
+              "green",
+              "blue",
+            ],
+            "type": "enum",
+          },
         },
       ],
       "name": "enum",

--- a/src/__tests__/fixed.test.ts
+++ b/src/__tests__/fixed.test.ts
@@ -26,6 +26,13 @@ test('should create fixed types', () => {
           nullable: true,
         }),
       )
+      .addField(
+        new FixedField({
+          name: 'fixed_field_customProp',
+          size: 52424302,
+          nullable: true,
+        }).prop('customProp', 'val'),
+      )
       .compile(),
   ).toMatchInlineSnapshot(`
     {
@@ -59,6 +66,19 @@ test('should create fixed types', () => {
             {
               "name": "fixed_field_key_override_example",
               "size": 12451302,
+              "type": "fixed",
+            },
+          ],
+        },
+        {
+          "customProp": "val",
+          "name": "fixed_field_customProp",
+          "type": [
+            "null",
+            {
+              "customProp": "val",
+              "name": "fixed_field_customProp",
+              "size": 52424302,
               "type": "fixed",
             },
           ],

--- a/src/__tests__/map.test.ts
+++ b/src/__tests__/map.test.ts
@@ -9,99 +9,113 @@ test('should create primitive type maps', () => {
           name: 'boolean_map',
           doc: 'boolean map',
           type: 'boolean',
-        }),
+        }).prop('customProp', 'val'),
       )
       .addField(
         new MapField({
           name: 'bytes_map',
           doc: 'bytes map',
           type: 'bytes',
-        }),
+        }).prop('customProp', 'val'),
       )
       .addField(
         new MapField({
           name: 'double_map',
           doc: 'double map',
           type: 'double',
-        }),
+        }).prop('customProp', 'val'),
       )
       .addField(
         new MapField({
           name: 'float_map',
           doc: 'float map',
           type: 'float',
-        }),
+        }).prop('customProp', 'val'),
       )
       .addField(
         new MapField({
           name: 'int_map',
           doc: 'int map',
           type: 'int',
-        }),
+        }).prop('customProp', 'val'),
       )
       .addField(
         new MapField({
           name: 'long_map',
           doc: 'long map',
           type: 'long',
-        }),
+        }).prop('customProp', 'val'),
       )
       .addField(
         new MapField({
           name: 'string_map',
           doc: 'string map',
           type: 'string',
-        }),
+        }).prop('customProp', 'val'),
       )
       .compile(),
   ).toMatchInlineSnapshot(`
     {
       "fields": [
         {
+          "customProp": "val",
           "name": "boolean_map",
           "type": {
+            "customProp": "val",
             "type": "map",
             "values": "boolean",
           },
         },
         {
+          "customProp": "val",
           "name": "bytes_map",
           "type": {
+            "customProp": "val",
             "type": "map",
             "values": "bytes",
           },
         },
         {
+          "customProp": "val",
           "name": "double_map",
           "type": {
+            "customProp": "val",
             "type": "map",
             "values": "double",
           },
         },
         {
+          "customProp": "val",
           "name": "float_map",
           "type": {
+            "customProp": "val",
             "type": "map",
             "values": "float",
           },
         },
         {
+          "customProp": "val",
           "name": "int_map",
           "type": {
+            "customProp": "val",
             "type": "map",
             "values": "int",
           },
         },
         {
+          "customProp": "val",
           "name": "long_map",
           "type": {
+            "customProp": "val",
             "type": "map",
             "values": "long",
           },
         },
         {
+          "customProp": "val",
           "name": "string_map",
           "type": {
+            "customProp": "val",
             "type": "map",
             "values": "string",
           },
@@ -125,8 +139,8 @@ test('should create complex type maps', () => {
           type: new EnumField({
             name: 'enum',
             type: ['v1', 'v2'],
-          }),
-        }),
+          }).prop('customProp', 'val'),
+        }).prop('customProp', 'val'),
       )
       .addField(
         new MapField({
@@ -136,8 +150,8 @@ test('should create complex type maps', () => {
           type: new EnumField({
             name: 'enum',
             type: ['v1', 'v2'],
-          }),
-        }),
+          }).prop('customProp', 'val'),
+        }).prop('customProp', 'val'),
       )
       .addField(
         new MapField({
@@ -150,15 +164,15 @@ test('should create complex type maps', () => {
               new PrimitiveField({
                 name: 'int_field',
                 type: 'int',
-              }),
+              }).prop('customProp', 'val'),
             )
             .addField(
               new PrimitiveField({
                 name: 'string_field',
                 type: 'string',
-              }),
+              }).prop('customProp', 'val'),
             ),
-        }),
+        }).prop('customProp', 'val'),
       )
       .addField(
         new MapField({
@@ -167,18 +181,21 @@ test('should create complex type maps', () => {
           type: new ArrayField({
             name: 'array_field',
             type: 'int',
-          }),
-        }),
+          }).prop('customProp', 'val'),
+        }).prop('customProp', 'val'),
       )
       .compile(),
   ).toMatchInlineSnapshot(`
     {
       "fields": [
         {
+          "customProp": "val",
           "name": "enum_map",
           "type": {
+            "customProp": "val",
             "type": "map",
             "values": {
+              "customProp": "val",
               "name": "enum",
               "symbols": [
                 "v1",
@@ -189,12 +206,15 @@ test('should create complex type maps', () => {
           },
         },
         {
+          "customProp": "val",
           "name": "enum_map_nullable",
           "type": [
             "null",
             {
+              "customProp": "val",
               "type": "map",
               "values": {
+                "customProp": "val",
                 "name": "enum",
                 "symbols": [
                   "v1",
@@ -206,16 +226,20 @@ test('should create complex type maps', () => {
           ],
         },
         {
+          "customProp": "val",
           "name": "record_map",
           "type": {
+            "customProp": "val",
             "type": "map",
             "values": {
               "fields": [
                 {
+                  "customProp": "val",
                   "name": "int_field",
                   "type": "int",
                 },
                 {
+                  "customProp": "val",
                   "name": "string_field",
                   "type": "string",
                 },
@@ -226,10 +250,13 @@ test('should create complex type maps', () => {
           },
         },
         {
+          "customProp": "val",
           "name": "array_map",
           "type": {
+            "customProp": "val",
             "type": "map",
             "values": {
+              "customProp": "val",
               "items": "int",
               "type": "array",
             },

--- a/src/__tests__/primitive.test.ts
+++ b/src/__tests__/primitive.test.ts
@@ -492,3 +492,109 @@ test('should create a schema - with default values', () => {
     }
   `);
 });
+
+test('should create a schema - with custom properties', () => {
+  expect(
+    new AvroSchemaBuilder('primitive')
+      .record('record.primitive')
+      .addField(
+        new PrimitiveField({
+          name: 'boolean_field',
+          type: 'boolean',
+        }).prop('customProp', 'val'),
+      )
+      .addField(
+        new PrimitiveField({
+          name: 'bytes_field',
+          type: 'bytes',
+        }).prop('customProp', 'val'),
+      )
+      .addField(
+        new PrimitiveField({
+          name: 'double_field',
+          type: 'double',
+        }).prop('customProp', 'val'),
+      )
+      .addField(
+        new PrimitiveField({
+          name: 'float_field',
+          type: 'float',
+        }).prop('customProp', 'val'),
+      )
+      .addField(
+        new PrimitiveField({
+          name: 'int_field',
+          type: 'int',
+        }).prop('customProp', 'val'),
+      )
+      .addField(
+        new PrimitiveField({
+          name: 'long_field',
+          type: 'long',
+        }).prop('customProp', 'val'),
+      )
+      .addField(
+        new PrimitiveField({
+          name: 'null_field',
+          type: 'null',
+        }).prop('customProp', 'val'),
+      )
+      .addField(
+        new PrimitiveField({
+          name: 'string_field',
+          type: 'string',
+        }).prop('customProp', 'val'),
+      )
+      .prop('customPropTopLevel', 'val')
+      .compile(),
+  ).toMatchInlineSnapshot(`
+    {
+      "customPropTopLevel": "val",
+      "fields": [
+        {
+          "customProp": "val",
+          "name": "boolean_field",
+          "type": "boolean",
+        },
+        {
+          "customProp": "val",
+          "name": "bytes_field",
+          "type": "bytes",
+        },
+        {
+          "customProp": "val",
+          "name": "double_field",
+          "type": "double",
+        },
+        {
+          "customProp": "val",
+          "name": "float_field",
+          "type": "float",
+        },
+        {
+          "customProp": "val",
+          "name": "int_field",
+          "type": "int",
+        },
+        {
+          "customProp": "val",
+          "name": "long_field",
+          "type": "long",
+        },
+        {
+          "customProp": "val",
+          "name": "null_field",
+          "type": "null",
+        },
+        {
+          "customProp": "val",
+          "name": "string_field",
+          "type": "string",
+        },
+      ],
+      "name": "primitive",
+      "namespace": "record.primitive",
+      "type": "record",
+    }
+  `);
+});

--- a/src/__tests__/record.test.ts
+++ b/src/__tests__/record.test.ts
@@ -324,3 +324,95 @@ test('should create nullable records', () => {
     }
   `);
 });
+
+test('should create customProp records', () => {
+  expect(
+    new AvroSchemaBuilder('myRecord')
+      .record('record.record')
+      .addField(
+        new RecordField({
+          namespace: 'record.primitive.x',
+          name: 'children',
+          doc: 'children field',
+          order: FieldOrder.ascending,
+          nullable: true,
+        })
+          .prop('customProp', 'val')
+          .addField(
+            new PrimitiveField({
+              name: 'id',
+              type: 'int',
+            }).prop('customProp', 'val'),
+          )
+          .addField(
+            new RecordField({
+              namespace: 'record.primitive.x.y',
+              name: 'grandchildren',
+              doc: 'children field',
+              order: FieldOrder.descending,
+              nullable: true,
+              defaultValue: null,
+            })
+              .prop('customProp', 'val')
+              .addField(
+                new PrimitiveField({
+                  name: 'id',
+                  type: 'int',
+                }).prop('customProp', 'val'),
+              ),
+          ),
+      )
+      .prop('customPropTopLevel', 'val')
+      .compile(),
+  ).toMatchInlineSnapshot(`
+    {
+      "customPropTopLevel": "val",
+      "fields": [
+        {
+          "customProp": "val",
+          "name": "children",
+          "type": [
+            "null",
+            {
+              "customProp": "val",
+              "fields": [
+                {
+                  "customProp": "val",
+                  "name": "id",
+                  "type": "int",
+                },
+                {
+                  "customProp": "val",
+                  "name": "grandchildren",
+                  "type": [
+                    "null",
+                    {
+                      "customProp": "val",
+                      "default": null,
+                      "fields": [
+                        {
+                          "customProp": "val",
+                          "name": "id",
+                          "type": "int",
+                        },
+                      ],
+                      "name": "grandchildren",
+                      "namespace": "record.primitive.x.y",
+                      "type": "record",
+                    },
+                  ],
+                },
+              ],
+              "name": "children",
+              "namespace": "record.primitive.x",
+              "type": "record",
+            },
+          ],
+        },
+      ],
+      "name": "myRecord",
+      "namespace": "record.record",
+      "type": "record",
+    }
+  `);
+});

--- a/src/__tests__/union.test.ts
+++ b/src/__tests__/union.test.ts
@@ -26,9 +26,17 @@ test('should create a schema with primitive values', () => {
           nullable: true,
         }),
       )
+      .addField(
+        new UnionField({
+          name: 'union_primitive_customProp',
+          types: ['int', 'string'],
+        }).prop('customProp', 'val'),
+      )
+      .prop('customPropTopLevel', 'val')
       .compile(),
   ).toMatchInlineSnapshot(`
     {
+      "customPropTopLevel": "val",
       "fields": [
         {
           "name": "union_primitive",
@@ -41,6 +49,14 @@ test('should create a schema with primitive values', () => {
           "name": "union_primitive_nullable",
           "type": [
             "null",
+            "int",
+            "string",
+          ],
+        },
+        {
+          "customProp": "val",
+          "name": "union_primitive_customProp",
+          "type": [
             "int",
             "string",
           ],
@@ -109,6 +125,33 @@ test('should create a schema with record types', () => {
           nullable: true,
         }),
       )
+      .addField(
+        new UnionField({
+          name: 'union_record_customProp',
+          types: [
+            new RecordField({
+              name: 'record_field_1',
+            }).addField(
+              new PrimitiveField({
+                name: 'int_field',
+                nullable: true,
+                type: 'int',
+              }).prop('customProp', 'val'),
+            ),
+
+            new RecordField({
+              name: 'record_field_2',
+            }).addField(
+              new PrimitiveField({
+                name: 'int_field',
+                type: 'int',
+              }),
+            ),
+          ],
+
+          nullable: true,
+        }).prop('customPropTopLevel', 'val'),
+      )
       .compile(),
   ).toMatchInlineSnapshot(`
     {
@@ -148,6 +191,37 @@ test('should create a schema with record types', () => {
             {
               "fields": [
                 {
+                  "name": "int_field",
+                  "type": [
+                    "null",
+                    "int",
+                  ],
+                },
+              ],
+              "name": "record_field_1",
+              "type": "record",
+            },
+            {
+              "fields": [
+                {
+                  "name": "int_field",
+                  "type": "int",
+                },
+              ],
+              "name": "record_field_2",
+              "type": "record",
+            },
+          ],
+        },
+        {
+          "customPropTopLevel": "val",
+          "name": "union_record_customProp",
+          "type": [
+            "null",
+            {
+              "fields": [
+                {
+                  "customProp": "val",
                   "name": "int_field",
                   "type": [
                     "null",
@@ -214,6 +288,23 @@ test('should create a schema with array types', () => {
           nullable: true,
         }),
       )
+      .addField(
+        new UnionField({
+          name: 'union_array_customProp',
+          types: [
+            new ArrayField({
+              name: 'array_field_1',
+              type: 'int',
+            }).prop('customProp', 'val'),
+            new ArrayField({
+              name: 'array_field_2',
+              type: 'string',
+            }),
+          ],
+
+          nullable: true,
+        }).prop('customPropTopLevel', 'val'),
+      )
       .compile(),
   ).toMatchInlineSnapshot(`
     {
@@ -236,6 +327,22 @@ test('should create a schema with array types', () => {
           "type": [
             "null",
             {
+              "items": "int",
+              "type": "array",
+            },
+            {
+              "items": "string",
+              "type": "array",
+            },
+          ],
+        },
+        {
+          "customPropTopLevel": "val",
+          "name": "union_array_customProp",
+          "type": [
+            "null",
+            {
+              "customProp": "val",
               "items": "int",
               "type": "array",
             },
@@ -289,6 +396,23 @@ test('should create a schema with map types', () => {
           nullable: true,
         }),
       )
+      .addField(
+        new UnionField({
+          name: 'union_map_customProp',
+          types: [
+            new MapField({
+              name: 'array_field_1',
+              type: 'int',
+            }).prop('customProp', 'val'),
+            new MapField({
+              name: 'array_field_2',
+              type: 'string',
+            }),
+          ],
+
+          nullable: true,
+        }).prop('customPropTopLevel', 'val'),
+      )
       .compile(),
   ).toMatchInlineSnapshot(`
     {
@@ -311,6 +435,22 @@ test('should create a schema with map types', () => {
           "type": [
             "null",
             {
+              "type": "map",
+              "values": "int",
+            },
+            {
+              "type": "map",
+              "values": "string",
+            },
+          ],
+        },
+        {
+          "customPropTopLevel": "val",
+          "name": "union_map_customProp",
+          "type": [
+            "null",
+            {
+              "customProp": "val",
               "type": "map",
               "values": "int",
             },
@@ -364,6 +504,23 @@ test('should create a schema with enum types', () => {
           nullable: true,
         }),
       )
+      .addField(
+        new UnionField({
+          name: 'union_enum_customProp',
+          types: [
+            new EnumField({
+              name: 'enum_field_1',
+              type: ['v1', 'v2', 'v3'],
+            }).prop('customProp', 'val'),
+            new EnumField({
+              name: 'enum_field_2',
+              type: ['v1', 'v2', 'v3'],
+            }),
+          ],
+
+          nullable: true,
+        }).prop('customPropTopLevel', 'val'),
+      )
       .compile(),
   ).toMatchInlineSnapshot(`
     {
@@ -396,6 +553,32 @@ test('should create a schema with enum types', () => {
           "type": [
             "null",
             {
+              "name": "enum_field_1",
+              "symbols": [
+                "v1",
+                "v2",
+                "v3",
+              ],
+              "type": "enum",
+            },
+            {
+              "name": "enum_field_2",
+              "symbols": [
+                "v1",
+                "v2",
+                "v3",
+              ],
+              "type": "enum",
+            },
+          ],
+        },
+        {
+          "customPropTopLevel": "val",
+          "name": "union_enum_customProp",
+          "type": [
+            "null",
+            {
+              "customProp": "val",
               "name": "enum_field_1",
               "symbols": [
                 "v1",
@@ -459,6 +642,23 @@ test('should create a schema with fixed types', () => {
           nullable: true,
         }),
       )
+      .addField(
+        new UnionField({
+          name: 'union_fixed_customProp',
+          types: [
+            new FixedField({
+              name: 'fixed_field_1',
+              size: 123,
+            }).prop('customProp', 'val'),
+            new FixedField({
+              name: 'fixed_field_2',
+              size: 5353,
+            }),
+          ],
+
+          nullable: true,
+        }).prop('customPropTopLevel', 'val'),
+      )
       .compile(),
   ).toMatchInlineSnapshot(`
     {
@@ -483,6 +683,24 @@ test('should create a schema with fixed types', () => {
           "type": [
             "null",
             {
+              "name": "fixed_field_1",
+              "size": 123,
+              "type": "fixed",
+            },
+            {
+              "name": "fixed_field_2",
+              "size": 5353,
+              "type": "fixed",
+            },
+          ],
+        },
+        {
+          "customPropTopLevel": "val",
+          "name": "union_fixed_customProp",
+          "type": [
+            "null",
+            {
+              "customProp": "val",
               "name": "fixed_field_1",
               "size": 123,
               "type": "fixed",

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,6 +88,7 @@ class BaseField {
   public readonly order?: types.FieldOrder;
   public readonly nullable?: boolean;
   public readonly keyName: string;
+  public readonly customProperties: Record<string, any>;
 
   constructor({params}: {params: types.NamedFieldParams & {nullable?: boolean}}) {
     this.name = params.name;
@@ -95,12 +96,19 @@ class BaseField {
     this.order = params.order;
     this.nullable = params.nullable;
     this.keyName = params.keyNameOverride || params.name;
+    this.customProperties = {};
+  }
+
+  public prop(key: string, value: any): this {
+    this.customProperties[key] = value;
+    return this;
   }
 }
 
 export class ReferenceField extends BaseField {
   public readonly type: string;
   public readonly nullable?: boolean;
+  public readonly customProperties: Record<string, any> = {};
 
   constructor(params: ReferenceFieldInput) {
     super({params: {...params, nullable: params.nullable}});
@@ -116,6 +124,7 @@ export class ReferenceField extends BaseField {
     const field: types.RecordFieldSerialized = {
       name: this.keyName,
       type: this.nullable && this.type !== 'null' ? ['null', this.getType()] : this.getType(),
+      ...this.customProperties,
     };
 
     if (this.order) {
@@ -148,6 +157,7 @@ export class PrimitiveField<T extends types.PrimitiveType> extends BaseField {
     const field: types.RecordFieldSerialized = {
       name: this.keyName,
       type: this.nullable && this.type !== 'null' ? ['null', this.getType()] : this.getType(),
+      ...this.customProperties,
     };
 
     if (this.order) {
@@ -186,6 +196,7 @@ export class EnumField extends BaseField {
       symbols: this.symbols,
       type: 'enum',
       name: this.name,
+      ...this.customProperties,
     };
 
     if (this.aliases) {
@@ -211,6 +222,7 @@ export class EnumField extends BaseField {
     return {
       name: this.keyName,
       type: this.nullable ? ['null', this.getType()] : this.getType(),
+      ...this.customProperties,
     };
   }
 }
@@ -231,6 +243,7 @@ export class FixedField extends BaseField {
       type: 'fixed',
       name: this.name,
       size: this.size,
+      ...this.customProperties,
     };
 
     if (this.aliases) {
@@ -244,6 +257,7 @@ export class FixedField extends BaseField {
     return {
       name: this.keyName,
       type: this.nullable ? ['null', this.getType()] : this.getType(),
+      ...this.customProperties,
     };
   }
 }
@@ -263,6 +277,7 @@ export class MapField extends BaseField {
     const arrayType: types.MapType = {
       type: 'map',
       values: typeof this._type === 'string' ? this._type : this._type.getType(),
+      ...this.customProperties,
     };
 
     return arrayType;
@@ -272,6 +287,7 @@ export class MapField extends BaseField {
     return {
       name: this.keyName,
       type: this.nullable ? ['null', this.getType()] : this.getType(),
+      ...this.customProperties,
     };
   }
 }
@@ -283,7 +299,6 @@ export class UnionField extends BaseField {
 
   constructor({types, nullable, ...params}: UnionFieldInput) {
     super({params});
-
     this._types = types;
     this.nullable = nullable;
   }
@@ -308,6 +323,7 @@ export class UnionField extends BaseField {
     return {
       name: this.keyName,
       type: this.getType(),
+      ...this.customProperties,
     };
   }
 }
@@ -329,6 +345,7 @@ export class ArrayField extends BaseField {
     const arrayType: types.ArrayType = {
       type: 'array',
       items: typeof this._type === 'string' ? this._type : this._type.getType(),
+      ...this.customProperties,
     };
 
     return arrayType;
@@ -338,6 +355,7 @@ export class ArrayField extends BaseField {
     const baseType: types.RecordFieldSerialized = {
       name: this.keyName,
       type: this.nullable ? ['null', this.getType()] : this.getType(),
+      ...this.customProperties,
     };
 
     if (this.defaultValue !== undefined) {
@@ -427,6 +445,7 @@ export class RecordField extends BaseField {
     return {
       name: this.keyName,
       type: this.nullable ? ['null', this.getType()] : this.getType(),
+      ...this.customProperties,
     };
   }
 
@@ -435,6 +454,7 @@ export class RecordField extends BaseField {
       type: 'record',
       name: this.name,
       fields: this._fields.compile(),
+      ...this.customProperties,
     };
 
     if (this.namespace) {


### PR DESCRIPTION
# Summary
Added custom properties like Apache Avro SchemaBuilder has: https://avro.apache.org/docs/1.7.6/api/java/org/apache/avro/SchemaBuilder.html. This will allow schema to contain custom metadata on fields which will greatly increase the use cases of Avro schemas.

# Description
All fields now have the method `.prop(string, any)` which will add a custom property to the field. This is the same syntax and output schema as Apache's SchemaBuilder: 

<img width="490" alt="image" src="https://github.com/user-attachments/assets/c0d40202-35ea-4371-9322-214629f95134">

# Testing
Added unit tests for all types.

# Issue
This PR will resolve issue #1 